### PR TITLE
Possible scrollbar_bg fix

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -115,8 +115,7 @@
                                 <div onclick="ChangeColor('#ba08ec', 'rgba(31, 0, 34, 0.7)')" class="ball purple"></div>       
                                 <div onclick="ChangeColor('#1c6ce8', 'rgb(8, 35, 64)')" class="ball blue"></div>
                                 <div onclick="ChangeColor('#d29524', 'rgba(43, 32, 11, 0.9)')" class="ball orange"></div>
-                                <div onclick="ChangeColor('#b9b724', 'rgba(0, 0, 0, 0.9)')" class="ball yellow"></div>                                    
-                            </div>
+                                <div onclick="ChangeColor('#b9b724', 'rgba(66, 67, 38, 0.9)')" class="ball yellow"></div>                                    
 
                     </div>
                     <div class="col-lg-4">


### PR DESCRIPTION
When yellow is selected in the demo, there does not appear to be a yellow-tinted background in the scroll bar. If this is intended, please excuse me. But I thought I'd offer a quick fix in case you wanted it to be like the other colors